### PR TITLE
Fix the paths to compilers that CMake uses.

### DIFF
--- a/autoibamr.sh
+++ b/autoibamr.sh
@@ -503,7 +503,9 @@ package_build() {
     elif [ ${BUILDCHAIN} = "cmake" ]; then
         rm -f ${BUILDDDIR}/CMakeCache.txt
         rm -rf ${BUILDDIR}/CMakeFiles
-        echo cmake ${CONFOPTS} -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} ${UNPACK_PATH}/${EXTRACTSTO} >>autoibamr_configure
+        echo cmake ${CONFOPTS} -DCMAKE_C_COMPILER="${CC}" \
+             -DCMAKE_CXX_COMPILER="${CXX}" -DCMAKE_Fortran_COMPILER="${FC}" \
+             -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} ${UNPACK_PATH}/${EXTRACTSTO} >>autoibamr_configure
         for target in "${TARGETS[@]}"; do
             echo make ${MAKEOPTS} -j ${JOBS} $target >>autoibamr_build
         done


### PR DESCRIPTION
I think this is a candi bug - we need full paths to compilers to make cmake happy.