### PR TITLE
Clean up some small stuff.

### DIFF
--- a/IBAMR-toolchain/packages/petsc.package
+++ b/IBAMR-toolchain/packages/petsc.package
@@ -27,6 +27,7 @@ CONFOPTS="
   --with-shared-libraries=1
   --with-mpi=1
   --with-x=0
+  --with-fortran-bindings=0
   --with-64-bit-indices=0
 "
 
@@ -79,7 +80,7 @@ if [ ! -z "${PARMETIS_DIR}" ]; then
     CONFOPTS="\
         ${CONFOPTS} \
         --with-parmetis-dir=${PARMETIS_DIR} \
-	--with-metis-dir=${PARMETIS_DIR}"
+        --with-metis-dir=${PARMETIS_DIR}"
 fi
 
 #########################################################################

--- a/IBAMR-toolchain/packages/zlib.package
+++ b/IBAMR-toolchain/packages/zlib.package
@@ -12,7 +12,7 @@ package_specific_build () {
     ./configure --prefix=${INSTALL_PATH}
     quit_if_fail "zlib configure failed"
     
-    make install
+    make -j${JOBS} install
     quit_if_fail "zlib make install failed"
 }
 

--- a/autoibamr.sh
+++ b/autoibamr.sh
@@ -693,9 +693,9 @@ default DEVELOPER_MODE=OFF
 default PACKAGES_OFF=""
 
 # all packages are mandatory except silo and libmesh
-PACKAGES="boost cmake git hdf5 muparser numdiff parmetis petsc zlib"
+PACKAGES="boost cmake git hdf5 muparser numdiff parmetis petsc"
 if [ ${BUILD_SILO} = "ON" ]; then
-    PACKAGES="${PACKAGES} silo"
+    PACKAGES="${PACKAGES} zlib silo"
 fi
 if [ ${BUILD_LIBMESH} = "ON" ]; then
     PACKAGES="${PACKAGES} libmesh"


### PR DESCRIPTION
1. We don't need PETSc's FORTRAN bindings and they are very slow to compile
2. compile zlib in parallel
3. we only need zlib if we have silo