### PR TITLE
Fix SAMRAI flags.

### DIFF
--- a/IBAMR-toolchain/packages/samrai.package
+++ b/IBAMR-toolchain/packages/samrai.package
@@ -29,11 +29,14 @@ CONFOPTS="
   --disable-deprecated
 "
 
+# We default to shared-object files in IBAMR so compile SAMRAI accordingly
+export CFLAGS=-fPIC
+export CXXFLAGS=-fPIC
+export FFLAGS=-fPIC
 if [ ${NATIVE_OPTIMIZATIONS} = ON ]; then
-    CONFOPTS="${CONFOPTS} \
-      COPTFLAGS='-O3 -march=native -mtune=native' \
-      CXXOPTFLAGS='-O3 -march=native -mtune=native' \
-      FOPTFLAGS='-O3 -march=native -mtune=native'"
+    export CFLAGS="${CFLAGS} -O3 -march=native"
+    export CXXFLAGS="${CXXFLAGS} -O3 -march=native"
+    export FFLAGS="${FFLAGS} -O3 -march=native"
 fi
 
 # SILO is still optional


### PR DESCRIPTION
1. We need -fPIC for shared object support in IBAMR.
2. SAMRAI doesn't recognize COPTFLAGS et al - we need CFLAGS etc.
3. Lets use export for these instead of worrying about quoting rules.