### PR TITLE
Fix silo package file.

### DIFF
--- a/IBAMR-toolchain/packages/silo.package
+++ b/IBAMR-toolchain/packages/silo.package
@@ -7,28 +7,18 @@ BUILDCHAIN=autotools
 
 INSTALL_PATH=${INSTALL_PATH}/${NAME}
 
-package_specific_build () {
-    cp -rf ${UNPACK_PATH}/${EXTRACTSTO}/* .
-    # TODO - error-out if ZLIB_INCLUDE contains a comma. Silo cannot handle
-    # that.
-    #
-    # Silo cannot be configured with shared libraries when python is not
-    # present, so it must be done statically.
-    ./configure                                             \
-            --prefix=${INSTALL_PATH}                        \
-            --enable-optimization                           \
-            --enable-silex                                  \
-            --enable-install-lite-headers                   \
-            --with-hdf5=${HDF5_DIR}/include,${HDF5_DIR}/lib \
-            --with-zlib=${ZLIB_INCLUDE},${ZLIB_LIBPATH}     \
-            CFLAGS="$CFLAGS -O2 -fPIC"                      \
-            CXXFLAGS="$CCFLAGS -O2 -fPIC"                   \
-            FFLAGS="$FFLAGS -fallow-argument-mismatch -O2 -fPIC"
-    quit_if_fail "silo configure failed"
-
-    make -j${JOBS} install
-    quit_if_fail "silo make install failed"
-}
+# Silo cannot be configured with shared libraries when python is not
+# present, so it must be done statically.
+#
+# Silo is too old to know about some changes made to HDF5 (notably the removal
+# of H5Pset_fapl_mpiposix) so we cannot configure with HDF5 either.
+CONFOPTS="
+--enable-optimization
+--with-zlib=${ZLIB_INCLUDE},${ZLIB_LIBPATH}
+CFLAGS='$CFLAGS -O2 -fPIC'
+CXXFLAGS='$CCFLAGS -O2 -fPIC'
+FFLAGS='$FFLAGS -fallow-argument-mismatch -O2 -fPIC'
+"
 
 package_specific_register () {
     export SILO_DIR=${INSTALL_PATH}


### PR DESCRIPTION
What we wrote before doesn't make sense - when we pick 'autotools' then autoibamr will run configure (and append the correct value for the installation prefix). We just need to set configuration options.