### PR TITLE
Remove a bunch of stuff that we don't support.

### DIFF
--- a/autoibamr.cfg
+++ b/autoibamr.cfg
@@ -27,17 +27,8 @@ INSTALL_PATH=${PREFIX_PATH}
 MIRROR=""
 
 #########################################################################
-# Choose additional configuration and components of IBAMR
-IBAMR_CONFOPTS=""
-
 # Option {ON|OFF}: Enable machine-specific optimizations (e.g. -march=native)?
 NATIVE_OPTIMIZATIONS=OFF
-
-# Option {ON|OFF}: Enable building IBAMR examples?
-BUILD_EXAMPLES=ON
-
-# Option {ON|OFF}: Run tests after installation?
-RUN_IBAMR_TESTS=OFF
 
 # Choose the python interpreter to use. We pick python2, python3,
 # python in that order by default. If you want to override this


### PR DESCRIPTION
- We don't need IBAMR_CONFOPTS: that is used in candi to figure out which packages we need, but we don't need anything like that here.
- We don't yet support installing examples so turn that off.
- We don't yet support running tests so turn that off.