### PR TITLE
Clean up some more zlib dependency tracking.

### DIFF
--- a/IBAMR-toolchain/packages/hdf5.package
+++ b/IBAMR-toolchain/packages/hdf5.package
@@ -9,6 +9,12 @@ PACKING=.tar.bz2
 BUILDCHAIN=autotools
 
 CONFOPTS="--enable-shared --enable-parallel"
+if [ ${SYSTEM_ZLIB_IN_STANDARD_LOCATION} = yes ]; then
+    CONFOPTS="${CONFOPTS} --with-zlib=yes"
+else
+    CONFOPTS="${CONFOPTS} --with-zlib=${ZLIB_DIR}"
+fi
+
 
 if [ ${DEBUGGING} = ON ]; then
     CONFOPTS="${CONFOPTS} --enable-symbols=yes --enable-asserts"

--- a/IBAMR-toolchain/packages/petsc.package
+++ b/IBAMR-toolchain/packages/petsc.package
@@ -21,6 +21,12 @@ CONFOPTS="
   --with-64-bit-indices=0
 "
 
+if [ ${SYSTEM_ZLIB_IN_STANDARD_LOCATION} = yes ]; then
+    CONFOPTS="${CONFOPTS} --with-zlib=1"
+else
+    CONFOPTS="${CONFOPTS} --with-zlib=${ZLIB_DIR}"
+fi
+
 if [ ${DEBUGGING} = ON ]; then
     CONFOPTS="${CONFOPTS} --with-debugging=1"
 else

--- a/autoibamr.sh
+++ b/autoibamr.sh
@@ -619,10 +619,11 @@ default DEVELOPER_MODE=OFF
 # TODO - we can probably remove this
 default PACKAGES_OFF=""
 
-# all packages are mandatory except silo and libmesh
-PACKAGES="cmake hdf5 numdiff petsc"
+# all packages are mandatory except Silo and libMesh. HDF5, PETSc, and Silo
+# depend on ZLIB: libMesh depends on PETSc.
+PACKAGES="cmake zlib hdf5 numdiff petsc"
 if [ ${BUILD_SILO} = "ON" ]; then
-    PACKAGES="${PACKAGES} zlib silo"
+    PACKAGES="${PACKAGES} silo"
 fi
 if [ ${BUILD_LIBMESH} = "ON" ]; then
     PACKAGES="${PACKAGES} libmesh"


### PR DESCRIPTION
This is only problematic if the system zlib installation exists but we are not using it.