### PR TITLE
Fix path resolution of FC.

### DIFF
--- a/autoibamr.sh
+++ b/autoibamr.sh
@@ -800,6 +800,7 @@ fi
 
 if [ -n "${FC}" ]; then
     cecho ${INFO} "FC  = $(which ${FC})"
+    export FC=$(which ${FC})
 else
     cecho ${BAD} "FC  variable not set. Please set it with \$export FC  = <(MPI) F90 compiler>"
 fi


### PR DESCRIPTION
I missed this back when we did full path resolution of compilers.

I think this worked by coincidence before since we never actually need to use the MPI Fortran wrapper - any fortran compiler will do since we never use it for linking.