### PR TITLE
Move two more things out of the configuration file.

### DIFF
--- a/autoibamr.cfg
+++ b/autoibamr.cfg
@@ -1,11 +1,5 @@
 # Global configuration.
 
-# Meta-project to build
-PROJECT=IBAMR-toolchain
-
-# Option {ON|OFF}: Use fresh build directory by remove existing ones?
-CLEAN_BUILD=OFF
-
 #########################################################################
 
 # Where do you want the downloaded source files to go?

--- a/autoibamr.sh
+++ b/autoibamr.sh
@@ -91,6 +91,7 @@ DEBUGGING=OFF
 NATIVE_OPTIMIZATIONS=OFF
 BUILD_LIBMESH=ON
 BUILD_SILO=ON
+CLEAN_BUILD=OFF
 
 while [ -n "$1" ]; do
     param="$1"
@@ -101,6 +102,7 @@ while [ -n "$1" ]; do
             echo ""
             echo "Usage: $0 [options]"
             echo "Options:"
+            echo "  --clean-build                  Delete all build directories before recompiling. By default build directories are kept."
             echo "  --disable-libmesh              Build IBAMR without libMesh. libMesh is on by default; this flag disables it."
             echo "  --disable-silo                 Build IBAMR without SILO. SILO is on by default; this flag disables it."
             echo "  --enable-debugging             build dependencies with assertions, optimizations, and debug symbols,"
@@ -112,6 +114,12 @@ while [ -n "$1" ]; do
             echo ""
             echo "The configuration including the choice of packages to install is stored in autoibamr.cfg, see README.md for more information."
             exit 0
+        ;;
+
+        #####################################
+        # clean build
+        --clean-build)
+            CLEAN_BUILD=ON
         ;;
 
         #####################################
@@ -659,7 +667,6 @@ default BUILD_PATH=${PREFIX_PATH}/tmp/build
 default INSTALL_PATH=${PREFIX_PATH}/packages
 default CONFIGURATION_PATH=${PREFIX_PATH}/configuration
 
-default CLEAN_BUILD=OFF
 default DEVELOPER_MODE=OFF
 
 # TODO - we can probably remove this


### PR DESCRIPTION
1. We don't support compiling anything but IBAMR.
2. make 'delete the build directories' an option.


Part of #57