### PR TITLE
Mention a workaround for accessing our dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ then install the latest IBAMR release and common dependencies:
 Follow the instructions on the screen
 (you can abort the process by pressing < CTRL > + C)
 
+Most of IBAMR's dependencies are hosted on GitHub. If you have trouble
+accessing GitHub then you may need to install a workaround. Some users have
+reported that GitHub520 can help - see issue #73 for more information if this
+applies to you.
+
 
 ### Installation
 


### PR DESCRIPTION
Fixes #73, at least as far as we can handle right now. Most but not all of our dependencies are only available on GitHub so we cannot really maintain a mirror list.