### PR TITLE
Help libMesh find PETSc.

### DIFF
--- a/IBAMR-toolchain/packages/libmesh.package
+++ b/IBAMR-toolchain/packages/libmesh.package
@@ -12,7 +12,9 @@ INSTALL_PATH=${INSTALL_PATH}/${EXTRACTSTO}
 
 #########################################################################
 
+# To pass a header check we need to help libMesh's configure script find PETSc. The test is run only with C so we only need to modify CFLAGS.
 CONFOPTS="
+  CFLAGS=-I${PETSC_DIR}/${PETSC_ARCH}/include
   --disable-boost
   --disable-capnproto
   --disable-cppunit


### PR DESCRIPTION
Fixes #84 - libMesh 1.6.2 needs some extra help finding new versions of PETSc.