### PR TITLE
Explicitly disable some silo stuff we never use.

### DIFF
--- a/IBAMR-toolchain/packages/silo.package
+++ b/IBAMR-toolchain/packages/silo.package
@@ -21,6 +21,10 @@ fi
 CONFOPTS="
 --enable-browser=no
 --enable-optimization
+--enable-silex=no
+--enable-hzip=no
+--enable-fpzip=no
+--enable-zfp=no
 --with-hdf5=${HDF5_DIR}/include,${HDF5_DIR}/lib,
 CFLAGS='${silo_compiler_flags}'
 CXXFLAGS='${silo_compiler_flags}'


### PR DESCRIPTION
I do not have these installed on any of my machines so I have no way to test whether or not IBAMR actually uses or works with these features. Some of them, like zfp, are definitely obsolete (HDF5 does not ship that any more).