### PR TITLE
Add a patch to enable compilation with very new versions of GNU make.

### DIFF
--- a/IBAMR-toolchain/packages/petsc.package
+++ b/IBAMR-toolchain/packages/petsc.package
@@ -67,6 +67,15 @@ package_specific_setup () {
     quit_if_fail "petsc make all install failed"
 }
 
+package_specific_patch () {
+    cd ${UNPACK_PATH}/${EXTRACTSTO}
+    quit_if_fail "cd failed"
+
+    cecho ${INFO} "Applying patches to petsc"
+    find "${ORIG_DIR}/${PROJECT}/patches/" -name "${NAME}-*.patch" -exec patch -p1 --input={} \;
+    quit_if_fail "Failed to apply a petsc patch."
+}
+
 package_specific_register () {
     export PETSC_DIR=${INSTALL_PATH}
     export PETSC_ARCH=""

--- a/IBAMR-toolchain/patches/petsc-lite-3.17.5-makeflags.patch
+++ b/IBAMR-toolchain/patches/petsc-lite-3.17.5-makeflags.patch
@@ -1,0 +1,45 @@
+diff --git a/lib/petsc/conf/rules b/lib/petsc/conf/rules
+index 7219d0274e7..a24e64130c4 100644
+--- a/lib/petsc/conf/rules
++++ b/lib/petsc/conf/rules
+@@ -53,7 +53,21 @@ ${PETSC_DIR}/${PETSC_ARCH}/tests/testfiles:
+ 	@${MKDIR} -p ${PETSC_DIR}/${PETSC_ARCH}/tests && touch -t 197102020000 ${PETSC_DIR}/${PETSC_ARCH}/tests/testfiles
+ 
+ libs: ${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/files ${PETSC_DIR}/${PETSC_ARCH}/tests/testfiles
+-	+@cd ${PETSC_DIR} && MAKEFLAGS="-j$(MAKE_NP) -l$(MAKE_LOAD) $(MAKEFLAGS)" ${OMAKE_PRINTDIR} -f gmakefile ${MAKE_PAR_OUT_FLG} V=${V} libs
++	+@r=`echo "${MAKEFLAGS}" | grep ' \-j'`; \
++        if [ "$$?" = 0 ]; then \
++          make_j="";\
++          echo "Skipping adding -jMAKE_NP option as -j option is already specified"; \
++        else \
++          make_j="-j${MAKE_NP}"; \
++        fi; \
++	r=`echo "${MAKEFLAGS}" | grep ' \-l'`; \
++        if [ "$$?" = 0 ]; then \
++          make_l="";\
++          echo "Skipping adding -lMAKE_LOAD option as -l option is already specified"; \
++        else \
++          make_l="-l${MAKE_LOAD}"; \
++        fi; \
++        cd ${PETSC_DIR} && ${OMAKE_PRINTDIR} -f gmakefile $${make_j} $${make_l} ${MAKE_PAR_OUT_FLG} V=${V} libs
+ 
+ # Does nothing; needed for some rules that require actions.
+ foo:
+diff --git a/makefile b/makefile
+index a8329057970..8cdd2fc5af1 100644
+--- a/makefile
++++ b/makefile
+@@ -122,8 +122,8 @@ info:
+ 	-@echo "------------------------------------------"
+ 	-@echo "Using mpiexec: ${MPIEXEC}"
+ 	-@echo "------------------------------------------"
+-	-@echo "Using MAKE: $(MAKE)"
+-	-@echo "Using MAKEFLAGS: -j$(MAKE_NP) -l$(MAKE_LOAD) $(MAKEFLAGS)"
++	-@echo "Using MAKE: ${MAKE}"
++	-@echo "Default MAKEFLAGS: MAKE_NP:${MAKE_NP} MAKE_LOAD:${MAKE_LOAD} MAKEFLAGS:${MAKEFLAGS}"
+ 	-@echo "=========================================="
+ 
+ #
+-- 
+2.25.1
+


### PR DESCRIPTION
Fixes #118. This works for older versions of Make - I need to test this with the latest version too to verify that this is the only place we need to patch.