### PR TITLE
resolves #121

### DIFF
--- a/autoibamr.sh
+++ b/autoibamr.sh
@@ -170,6 +170,7 @@ while [ -n "$1" ]; do
         # debug builds
         --enable-debugging)
             DEBUGGING=ON
+	    PREFIX=~/autoibamr-dbg
         ;;
 
         #####################################


### PR DESCRIPTION
change default debug prefix to ~/autoibamr-dbg, opt build still defaults to ~/autoibamr