### PR TITLE
Update both libMesh and PETSc.

### DIFF
--- a/IBAMR-toolchain/packages/libmesh.package
+++ b/IBAMR-toolchain/packages/libmesh.package
@@ -1,5 +1,5 @@
-VERSION=1.6.2
-CHECKSUM=745874f2b19f9345aac1676ea11deba8ac7f18b3
+VERSION=1.7.1
+CHECKSUM=df13cc53f149d3378b90064fd46eeddf75e0ea45b39f38e55c65faddf7f5b060
 
 NAME=libmesh-${VERSION}
 SOURCE=https://github.com/libMesh/libmesh/releases/download/v${VERSION}/
@@ -18,11 +18,13 @@ CONFOPTS="
   --disable-boost
   --disable-capnproto
   --disable-cppunit
+  --disable-curl
   --disable-eigen
   --disable-fparser
   --disable-hdf5
   --disable-laspack
   --disable-metaphysicl
+  --disable-nlopt
   --disable-openmp
   --disable-perflog
   --disable-pthreads
@@ -32,6 +34,7 @@ CONFOPTS="
   --disable-tbb
   --disable-tecio
   --disable-trilinos
+  --disable-vtk
   --enable-curl=no
   --enable-exodus=yes
   --enable-glpk=no

--- a/IBAMR-toolchain/packages/petsc.package
+++ b/IBAMR-toolchain/packages/petsc.package
@@ -1,8 +1,8 @@
-VERSION=3.17.5
-CHECKSUM=a1193e6c50a1676c3972a1edf0a06eec9fac8ecc2f3771f2689a8997423e4c71
+VERSION=3.21.2
+CHECKSUM=a1ac62b6204bdf2f7f9b637abf45e6cff24d372d4d3d3702c50e157bdb56eb21
 
 NAME=petsc-lite-${VERSION}
-SOURCE=http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/
+SOURCE=https://web.cels.anl.gov/projects/petsc/download/release-snapshots/
 PACKING=.tar.gz
 
 EXTRACTSTO=petsc-${VERSION}

--- a/IBAMR-toolchain/patches/libmesh-1.7.1-petsc.patch
+++ b/IBAMR-toolchain/patches/libmesh-1.7.1-petsc.patch
@@ -1,0 +1,141 @@
+diff --git ./contrib/timpi/configure ./contrib/timpi/configure
+index 1f4366a12..f16132fc1 100755
+--- ./contrib/timpi/configure
++++ ./contrib/timpi/configure
+@@ -7154,8 +7154,8 @@ if test "x$enablempi" = xyes; then :
+ 
+ 
+ 
+-
+-if test x"$MPI_USING_WRAPPERS" = x1; then :
++# in autoibamr we always use the wrappers, so manually override this to fix libMesh's detection logic
++if test x1 = x1; then :
+ 
+     ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+diff --git ./configure ./configure
+index 1f4366a12..f16132fc1 100755
+--- ./configure
++++ ./configure
+@@ -48122,8 +48122,8 @@ if test "x$enablempi" = xyes; then :
+ 
+ 
+ 
+-
+-if test x"$MPI_USING_WRAPPERS" = x1; then :
++# in autoibamr we always use the wrappers, so manually override this to fix libMesh's detection logic
++if test x1 = x1; then :
+ 
+     ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+diff --git ./src/solvers/petsc_dm_wrapper.C ./src/solvers/petsc_dm_wrapper.C
+index 41cdd1aaa..b7623f64f 100644
+--- ./src/solvers/petsc_dm_wrapper.C
++++ ./src/solvers/petsc_dm_wrapper.C
+@@ -188,7 +188,8 @@ namespace libMesh
+           ierr = DMCreateSubDM_Section_Private(dm, numFields, fields, is, subdm);
+           CHKERRQ(ierr);
+ #else
+-          ierr = DMCreateSectionSubDM(dm, numFields, fields, is, subdm);
++          const int num_comps = PETSC_DECIDE;
++          ierr = DMCreateSectionSubDM(dm, numFields, fields, &num_comps, nullptr, is, subdm);
+           CHKERRQ(ierr);
+ #endif
+         }
+diff --git ./src/solvers/petsc_linear_solver.C ./src/solvers/petsc_linear_solver.C
+index a09249a80..1b54a57d5 100644
+--- ./src/solvers/petsc_linear_solver.C
++++ ./src/solvers/petsc_linear_solver.C
+@@ -1422,7 +1422,6 @@ LinearConvergenceReason PetscLinearSolver<T>::get_converged_reason() const
+     case KSP_CONVERGED_ITS             : return CONVERGED_ITS;
+     case KSP_CONVERGED_CG_NEG_CURVE    : return CONVERGED_CG_NEG_CURVE;
+     case KSP_CONVERGED_CG_CONSTRAINED  : return CONVERGED_CG_CONSTRAINED;
+-    case KSP_CONVERGED_STEP_LENGTH     : return CONVERGED_STEP_LENGTH;
+     case KSP_CONVERGED_HAPPY_BREAKDOWN : return CONVERGED_HAPPY_BREAKDOWN;
+     case KSP_DIVERGED_NULL             : return DIVERGED_NULL;
+     case KSP_DIVERGED_ITS              : return DIVERGED_ITS;
+diff --git ./src/solvers/petscdmlibmeshimpl.C ./src/solvers/petscdmlibmeshimpl.C
+index 95f9baa9c..dd257bb0f 100644
+--- ./src/solvers/petscdmlibmeshimpl.C
++++ ./src/solvers/petscdmlibmeshimpl.C
+@@ -100,7 +100,7 @@ PetscErrorCode DMlibMeshSetSystem_libMesh(DM dm, NonlinearImplicitSystem & sys)
+   PetscBool islibmesh;
+   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
+   CHKERRQ(ierr);
+-  if (!islibmesh) LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
++  if (!islibmesh) SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "DM has wrong type");
+ 
+   if (dm->setupcalled) SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONGSTATE, "Cannot reset the libMesh system after DM has been set up.");
+   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
+@@ -160,7 +160,7 @@ PetscErrorCode DMlibMeshGetSystem_libMesh(DM dm, NonlinearImplicitSystem *& sys)
+   PetscValidHeaderSpecific(dm,DM_CLASSID,1);
+   PetscBool islibmesh;
+   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);CHKERRQ(ierr);
+-  if (!islibmesh) LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
++  if (!islibmesh) SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "DM has wrong type");
+   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
+   sys = dlm->sys;
+   PetscFunctionReturn(0);
+@@ -178,7 +178,7 @@ PetscErrorCode DMlibMeshGetBlocks(DM dm, PetscInt * n, char *** blocknames)
+   PetscBool islibmesh;
+   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
+   CHKERRQ(ierr);
+-  if (!islibmesh) LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
++  if (!islibmesh) SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "DM has wrong type");
+   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
+   PetscValidPointer(n,2);
+   *n = cast_int<unsigned int>(dlm->blockids->size());
+@@ -204,7 +204,7 @@ PetscErrorCode DMlibMeshGetVariables(DM dm, PetscInt * n, char *** varnames)
+   PetscInt i;
+   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
+   CHKERRQ(ierr);
+-  if (!islibmesh) LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
++  if (!islibmesh) SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "DM has wrong type");
+   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
+   PetscValidPointer(n,2);
+   *n = cast_int<unsigned int>(dlm->varids->size());
+@@ -491,7 +491,7 @@ PetscErrorCode DMlibMeshCreateFieldDecompositionDM(DM dm, PetscInt dnumber, Pets
+   PetscValidHeaderSpecific(dm,DM_CLASSID,1);
+   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
+   CHKERRQ(ierr);
+-  if (!islibmesh) LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
++  if (!islibmesh) SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "DM has wrong type");
+   if (dnumber < 0) LIBMESH_SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Negative number %D of decomposition parts", dnumber);
+   PetscValidPointer(ddm,5);
+   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
+@@ -544,7 +544,7 @@ PetscErrorCode DMlibMeshCreateDomainDecompositionDM(DM dm, PetscInt dnumber, Pet
+   PetscValidHeaderSpecific(dm,DM_CLASSID,1);
+   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
+   CHKERRQ(ierr);
+-  if (!islibmesh) LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
++  if (!islibmesh) SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "DM has wrong type");
+   if (dnumber < 0) LIBMESH_SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Negative number %D of decomposition parts", dnumber);
+   PetscValidPointer(ddm,5);
+   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
+@@ -772,7 +772,7 @@ static PetscErrorCode DMCreateGlobalVector_libMesh(DM dm, Vec *x)
+   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH, &eq); CHKERRQ(ierr);
+ 
+   if (!eq)
+-    LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "DM of type %s, not of type %s", ((PetscObject)dm)->type, DMLIBMESH);
++    SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "DM has wrong type");
+ 
+   if (!dlm->sys)
+     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No libMesh system set for DM_libMesh");
+@@ -819,7 +819,7 @@ static PetscErrorCode DMCreateMatrix_libMesh(DM dm, Mat * A)
+   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH, &eq); CHKERRQ(ierr);
+ 
+   if (!eq)
+-    LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "DM of type %s, not of type %s", ((PetscObject)dm)->type, DMLIBMESH);
++    SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "DM has wrong type");
+ 
+   if (!dlm->sys)
+     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No libMesh system set for DM_libMesh");
+@@ -901,7 +901,7 @@ static PetscErrorCode  DMSetUp_libMesh(DM dm)
+   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH, &eq); CHKERRQ(ierr);
+ 
+   if (!eq)
+-    LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "DM of type %s, not of type %s", ((PetscObject)dm)->type, DMLIBMESH);
++    SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "DM has wrong type");
+ 
+   if (!dlm->sys)
+     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No libMesh system set for DM_libMesh");


### PR DESCRIPTION
We need to update PETSc to work around a compilation error in metis with GCC-14. Since libMesh uses private PETSc APIs it also needs to be updated (and also patched).