### PR TITLE
Give NetCDF's config.h header the highest precedence.

### DIFF
--- a/IBAMR-toolchain/packages/netcdf.package
+++ b/IBAMR-toolchain/packages/netcdf.package
@@ -23,6 +23,15 @@ CONFOPTS="
 -DENABLE_EXAMPLES=OFF
 "
 
+package_specific_patch () {
+    cd ${UNPACK_PATH}/${EXTRACTSTO}
+    quit_if_fail "cd failed"
+
+    cecho ${INFO} "Applying patches to NetCDF"
+    find "${ORIG_DIR}/IBAMR-toolchain/patches/" -name "netcdf-${VERSION}-*.patch" -exec patch --remove-empty-files -p1 --input={} \;
+    quit_if_fail "Failed to apply a NetCDF patch."
+}
+
 package_specific_register () {
     export NETCDF_DIR=${INSTALL_PATH}
 }

--- a/IBAMR-toolchain/patches/netcdf-4.9.2-config-precedence.patch
+++ b/IBAMR-toolchain/patches/netcdf-4.9.2-config-precedence.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index de95010c6..b6736f352 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2269,7 +2269,7 @@ ENDFUNCTION()
+ configure_file("${netCDF_SOURCE_DIR}/config.h.cmake.in"
+   "${netCDF_BINARY_DIR}/config.h")
+ ADD_DEFINITIONS(-DHAVE_CONFIG_H)
+-INCLUDE_DIRECTORIES(${netCDF_BINARY_DIR})
++INCLUDE_DIRECTORIES(BEFORE ${netCDF_BINARY_DIR})
+ # End autotools-style checs for config.h
+ 
+ #####


### PR DESCRIPTION
This fixes a bug where there is another config.h header somewhere in the system path.

To the best of my knowledge this is now fixed upstream since external dependencies now use `-isystem` (which cmake always places last in the includes list).