### PR TITLE
Update to CMake 3.30.6.

### DIFF
--- a/IBAMR-toolchain/packages/cmake.package
+++ b/IBAMR-toolchain/packages/cmake.package
@@ -1,21 +1,22 @@
-MAJOR=3.28
-MINOR=4
+MAJOR=3.30
+MINOR=6
 VERSION=${MAJOR}.${MINOR}
 PACKING=.tar.gz
 
 if [ ${CMAKE_LOAD_TARBALL} = ON ] && [ ${PLATFORM_OSTYPE} == "linux" ]; then
     # tarball install
     NAME=cmake-${VERSION}-linux-x86_64
-    CHECKSUM=1f74731c80cbba3263c64fca6f6af0fb8dd1d06365425e404f79564773080d11
+    CHECKSUM=528350c72d89f3b408d12869daa282960dec4dd18224a22bddb52da526655359
     BUILDCHAIN=ignore
 else
     # configure/make/install
     NAME=cmake-${VERSION}
-    CHECKSUM=eb9c787e078848dc493f4f83f8a4bbec857cd1f38ab6425ce8d2776a9f6aa6fb
+    CHECKSUM=a7aa25cdd8545156fe0fec95ebbd53cb2b5173a8717e227f6e8a755185c168cf
 
     if builtin command -v cmake > /dev/null; then
         # configure/make with cmake (older or newer version already installed)    
         BUILDCHAIN=cmake
+        CONFOPTS="-DCMAKE_USE_OPENSSL=OFF"
     else
         # configure/make with autotools
         BUILDCHAIN=autotools


### PR DESCRIPTION
This is necessary to fix a bug where zlib (bundled by cmake) versions prior to 1.3 could not be compiled with macOS.