### PR TITLE
Fix a SAMRAI patch.

### DIFF
--- a/IBAMR-toolchain/patches/SAMRAI-2025.01.09-gcc15.patch
+++ b/IBAMR-toolchain/patches/SAMRAI-2025.01.09-gcc15.patch
@@ -1,3 +1,24 @@
+diff --git a/source/patchdata/array/ArrayData.C b/source/patchdata/array/ArrayData.C
+index baa7901..233b01f 100644
+--- a/source/patchdata/array/ArrayData.C
++++ b/source/patchdata/array/ArrayData.C
+@@ -21,6 +21,7 @@
+ #include "CopyOperation.h"
+ #include "SumOperation.h"
+ 
++#include <limits>
+ 
+ #define PDAT_ARRAYDATA_VERSION 1
+ 
+@@ -967,7 +968,7 @@ void ArrayData<DIM,TYPE>::getSpecializedFromDatabase(
+ template<int DIM, class TYPE>
+ void ArrayData<DIM,TYPE>::undefineData()
+ {
+-   fillAll(  tbox::MathUtilities<TYPE>::getSignalingNaN() );
++   fillAll(  std::numeric_limits<TYPE>::max() );
+ }
+ 
+ /*
 diff --git a/source/toolbox/base/MathUtilitiesSpecial.C b/source/toolbox/base/MathUtilitiesSpecial.C
 index ab846ac..e4e07bd 100644
 --- a/source/toolbox/base/MathUtilitiesSpecial.C


### PR DESCRIPTION
Follow-up to #187.

This fixes a bug in SAMRAI where the NaN value was always set to a max, which is required when creating the initial grid so that the workload is greater than zero (a comparison which always fails when it is a NaN).

Since SAMRAI set its internal signaling NaN wrapper to `DBL_MAX` 100% of the time (since it looked for macros which could never be defined) this bug was hidden by that choice but present after #187.