### PR TITLE
Enable selecting between fblaslapack and openblas.

### DIFF
--- a/IBAMR-toolchain/packages/petsc.package
+++ b/IBAMR-toolchain/packages/petsc.package
@@ -33,7 +33,7 @@ else
     CONFOPTS="${CONFOPTS} --with-debugging=0"
 fi
 
-for external_pkg in openblas hypre metis parmetis; do
+for external_pkg in ${PETSC_LAPACK_LIBRARY} hypre metis parmetis; do
     CONFOPTS="${CONFOPTS} --download-${external_pkg}=1"
 done
 


### PR DESCRIPTION
To use autoibamr with callgrind on Sycamore I need to avoid openblas - lets make that an option.