### PR TITLE
Revert unset ld variables

### DIFF
--- a/autoibamr.sh
+++ b/autoibamr.sh
@@ -1230,6 +1230,16 @@ if [ -z "${CC}" ] || [ -z "${CXX}" ] || [ -z "${FC}" ]; then
     exit 1
 fi
 
+if [ -n "${LD_PRELOAD}" ]; then
+    cecho ${INFO} "LD_PRELOAD=${LD_PRELOAD}. This flag may be set by a module"
+    cecho ${INFO} "but should not be set otherwise."
+fi
+
+if [ -n "${LD_LIBRARY_PATH}" ]; then
+    cecho ${INFO} "LD_LIBRARY_PATH=${LD_LIBRARY_PATH} This flag may be set by a"
+    cecho ${INFO} "module but should not be set otherwise."
+fi
+
 ################################################################################
 # If interaction is enabled, force the user to accept the current output
 if [ ${USER_INTERACTION} = ON ]; then

--- a/autoibamr.sh
+++ b/autoibamr.sh
@@ -72,10 +72,6 @@ unset LIBS
 unset LDFLAGS
 unset METHODS
 
-# also prevent hijacking of the link path
-unset LD_LIBRARY_PATH
-unset LD_PRELOAD
-
 ################################################################################
 # Define autoibamr helper functions
 


### PR DESCRIPTION
Reverts #212. Since modules set these values (e.g., to override system-level libraries) we have to keep them.