### PR TITLE
Add optional PETSc Kokkos support

### DIFF
--- a/IBAMR-toolchain/packages/petsc.package
+++ b/IBAMR-toolchain/packages/petsc.package
@@ -37,6 +37,10 @@ for external_pkg in ${PETSC_LAPACK_LIBRARY} hypre metis parmetis; do
     CONFOPTS="${CONFOPTS} --download-${external_pkg}=1"
 done
 
+if [ "${PETSC_KOKKOS}" = "ON" ]; then
+    CONFOPTS="${CONFOPTS} --download-kokkos=1 --download-kokkos-kernels=1"
+fi
+
 #########################################################################
 
 package_specific_setup () {

--- a/README.md
+++ b/README.md
@@ -316,6 +316,14 @@ optimizations, and debug symbols. In this case autoibamr is installed into
 ```
 Turns on processor-specific optimizations. Incompatible with debug mode.
 
+#### PETSc Kokkos support: `--enable-petsc-kokkos`
+```bash
+  ./autoibamr.sh --enable-petsc-kokkos
+```
+Builds PETSc with Kokkos and Kokkos Kernels via `--download-kokkos` and
+`--download-kokkos-kernels`. This may require a newer C++ toolchain
+(typically C++17-capable compiler wrappers).
+
 #### User interaction: ``[-y]``, ``[--yes]``, ``[--assume-yes]``
 ```bash
   ./autoibamr.sh -y

--- a/autoibamr.sh
+++ b/autoibamr.sh
@@ -141,6 +141,7 @@ JOBS=1
 NATIVE_OPTIMIZATIONS=OFF
 NATIVE_OPTIMIZATION_FLAGS="-march=native"
 PETSC_LAPACK_LIBRARY=openblas
+PETSC_KOKKOS=OFF
 PREFIX=~/autoibamr
 USER_PREFIX_SET=OFF
 USER_INTERACTION=ON
@@ -212,6 +213,8 @@ while [ -n "$1" ]; do
             echo "                                         openblas). Defaults to openblas. Openblas is more performant but, due to"
             echo "                                         its use of machine-specific optimizations, may not work with callgrind or"
             echo "                                         other profiling tools."
+            echo "  --enable-petsc-kokkos                 Build PETSc with Kokkos and Kokkos Kernels support."
+            echo "                                         This increases PETSc's C++ requirements (typically C++17)."
             echo "  --python-interpreter                   Absolute path to a python interpreter. Defaults to the first of"
             echo "                                         {python,python3,python2.7} found on the present machine."
             echo "  --disable-external-zlib                By default, autoibamr will attempt to detect and use the system installation"
@@ -311,6 +314,12 @@ while [ -n "$1" ]; do
 
         --lapack-library=*)
             PETSC_LAPACK_LIBRARY="${param#*=}"
+        ;;
+
+        #####################################
+        # PETSc Kokkos support
+        --enable-petsc-kokkos)
+            PETSC_KOKKOS=ON
         ;;
 
         #####################################
@@ -485,6 +494,11 @@ if [ "${PETSC_LAPACK_LIBRARY}" != "fblaslapack" ] && [ "${PETSC_LAPACK_LIBRARY}"
   exit 1
 fi
 cecho ${INFO} "Setting up PETSc with ${PETSC_LAPACK_LIBRARY}"
+if [ "${PETSC_KOKKOS}" = "ON" ]; then
+  cecho ${INFO} "Setting up PETSc with Kokkos and Kokkos Kernels"
+else
+  cecho ${INFO} "Setting up PETSc without Kokkos and Kokkos Kernels"
+fi
 
 
 if [ ${DEBUGGING} = "ON" ] && [ ${ASSERTIONS_WITH_OPTIMIZATIONS} = "ON" ]; then


### PR DESCRIPTION
## Summary
- add a new installer flag `--enable-petsc-kokkos` in `autoibamr.sh`
- thread the new toggle into PETSc configure options so PETSc is built with `--download-kokkos=1 --download-kokkos-kernels=1` when enabled
- document the new option in `README.md`

## Why
This enables opting into PETSc's Kokkos backend through autoibamr without changing defaults.

## Validation
- `bash -n autoibamr.sh`
- `bash -n IBAMR-toolchain/packages/petsc.package`
- `./autoibamr.sh --help | rg -n "petsc-kokkos"`
